### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/sqlmesh/cli/SQLMeshCLI.java
+++ b/src/main/java/io/kestra/plugin/sqlmesh/cli/SQLMeshCLI.java
@@ -103,10 +103,11 @@ public class SQLMeshCLI extends Task implements RunnableTask<ScriptOutput>, Name
         title = "Extra environment variables",
         description = "Key-value map merged into the task environment; values support templating."
     )
-    @PluginProperty(group = "execution", 
+    @PluginProperty(group = "execution",
         additionalProperties = String.class,
         dynamic = true
     )
+    @ToString.Exclude
     protected Map<String, String> env;
 
     @Schema(


### PR DESCRIPTION
## Summary

Remediates all findings from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **[LOW]** @ToString on class with env map that may hold rendered secrets (`src/main/java/io/kestra/plugin/sqlmesh/cli/SQLMeshCLI.java:110`)
  - Fix: Added `@ToString.Exclude` on the `env` field to prevent plaintext secret values from appearing in log lines when Lombok's generated `toString()` is called after `runContext.render()` resolves secrets stored in the environment map.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests
- [ ] Manually verified the patched code paths

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-sqlmesh/issues/85
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)

---
*Automated security fix — please review each change carefully before merging.*
